### PR TITLE
PdoDataSource should check error against SQLSTATE

### DIFF
--- a/koolreport/datasources/PdoDataSource.php
+++ b/koolreport/datasources/PdoDataSource.php
@@ -197,7 +197,7 @@ class PdoDataSource extends DataSource
 		$stm->execute();
 
 		$error = $stm->errorInfo();
-		if($error[2]!=null)
+		if($error[0]!='00000') // check again SQLSTATE error code
 		{
 			throw new \Exception("Query Error >> [".$error[2]."] >> $query");
 			return;


### PR DESCRIPTION
Correct sql error check (see http://php.net/manual/en/pdo.errorinfo.php):

> If the SQLSTATE error code is not set or there is no driver-specific error, the elements following element 0 will be set to NULL.